### PR TITLE
Add new input type BS.form.field.NamespaceTag

### DIFF
--- a/resources/bluespice.extjs/BS/form/field/NamespaceTag.js
+++ b/resources/bluespice.extjs/BS/form/field/NamespaceTag.js
@@ -1,0 +1,25 @@
+Ext.define( 'BS.form.field.NamespaceTag', {
+	extend: 'Ext.form.field.Tag',
+	displayField: 'namespace',
+	labelAlign: 'right',
+	valueField: 'id',
+	queryMode: 'local',
+	typeAhead: true,
+	triggerAction: 'all',
+	multiSelect: true,
+	collapseOnSelect: true,
+	fieldLabel: mw.message('bs-extjs-label-namespace').plain(),
+	emptyText: mw.message( "bs-extjs-combo-box-default-placeholder" ).plain(),
+	delimiter: ', ',
+	//Custom Settings
+	includeAll: false,
+	excludeIds: [],
+
+	initComponent: function() {
+		this.store = bs.extjs.newLocalNamespacesStore({
+			includeAll: this.includeAll,
+			excludeIds: this.excludeIds
+		});
+		this.callParent(arguments);
+	}
+});


### PR DESCRIPTION
Added NamespaceTag to be able to select multiple namespaces for PageTemplate
(related to this PR https://github.com/wikimedia/mediawiki-extensions-BlueSpicePageTemplates/pull/1/files)